### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/tactical-overview/configs.xml
+++ b/tactical-overview/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>Widget for displaying Host Status and service status Summary</description>
-    <version>21.10.0-beta.1</version>
+    <version>21.10.0</version>
     <keywords>centreon, widget, host, monitoring, service</keywords>
     <screenshot></screenshot>
     <thumbnail>./widgets/tactical-overview/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix